### PR TITLE
Update description to match upstream README

### DIFF
--- a/com.github.debauchee.barrier.appdata.xml
+++ b/com.github.debauchee.barrier.appdata.xml
@@ -6,10 +6,11 @@
   <summary>Barrier - Share mouse and keyboard over the local network</summary>
   <description>
     <p>What is it?</p>
-    <p>Barrier is KVM software forked from Symless's synergy 1.9 codebase. Synergy was a commercialized reimplementation of the original CosmoSynergy written by Chris Schoeneman.</p>
+    <p>Barrier is software that mimics the functionality of a KVM switch, which historically would allow you to use a single keyboard and mouse to control multiple computers by physically turning a dial on the box to switch the machine you're controlling at any given moment. Barrier does this in software, allowing you to tell it which machine to control by moving your mouse to the edge of the screen, or by using a keypress to switch focus to a different system.</p>
+    <p>Barrier was forked from Symless's Synergy 1.9 codebase. Synergy was a commercialized reimplementation of the original CosmoSynergy written by Chris Schoeneman.</p>
 
     <p>What's different?</p>
-    <p>Whereas synergy has moved beyond its goals from the 1.x era, Barrier aims to maintain that simplicity. Barrier will let you use your keyboard and mouse from machine A to control machine B (or more). It's that simple.</p>
+    <p>Whereas Synergy has moved beyond its goals from the 1.x era, Barrier aims to maintain that simplicity. Barrier will let you use your keyboard and mouse from machine A to control machine B (or more). It's that simple.</p>
 
     <p>Project goals</p>
     <p>Hassle-free reliability. We are users, too. Barrier was created so that we could solve the issues we had with synergy and then share these fixes with other users.</p>


### PR DESCRIPTION
Upstream updated their README.md in the following commit:
https://github.com/debauchee/barrier/commit/b2324f0d241752e21b5cce56caa3f23c30f6ed7f