### PR TITLE
Update Barrier version to v2.3.4 and KDE runtime to 5.15-21.08

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/build/
+/.flatpak-builder/

--- a/com.github.debauchee.barrier.appdata.xml
+++ b/com.github.debauchee.barrier.appdata.xml
@@ -22,8 +22,9 @@
   <url type="homepage">https://github.com/debauchee/barrier/</url>
   <url type="bugtracker">https://github.com/debauchee/barrier/issues/</url>
   <launchable type="desktop-id">com.github.debauchee.barrier.desktop</launchable>
- 
+
   <releases>
+    <release date="2022-03-07" version="2.3.4" urgency="medium" />
     <release date="2020-07-14" version="2.3.3" urgency="medium" />
     <release date="2019-09-03" version="2.3.2" urgency="medium" />
     <release date="2019-08-09" version="2.3.1" urgency="medium" />
@@ -31,7 +32,7 @@
     <release date="2019-01-11" version="2.1.2" urgency="medium" />
     <release date="2018-07-02" version="2.1.1" urgency="medium" />
   </releases>
- 
+
   <project_group>Debauchee</project_group>
   <project_license>GPL-2.0</project_license>
   <developer_name>Siix</developer_name>
@@ -55,6 +56,6 @@
   </screenshots>
 
   <update_contact>barrier+flatpak@shymega.org.uk</update_contact>
- 
+
   <content_rating type="oars-1.1" />
 </component>

--- a/com.github.debauchee.barrier.json
+++ b/com.github.debauchee.barrier.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.github.debauchee.barrier",
     "runtime" : "org.kde.Platform",
-    "runtime-version" : "5.15",
+    "runtime-version" : "5.15-21.08",
     "sdk" : "org.kde.Sdk",
     "command" : "barrier",
     "rename-icon" : "barrier",
@@ -36,8 +36,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/openssl/openssl/archive/OpenSSL_1_1_1g.tar.gz",
-                    "sha256": "281e4f13142b53657bd154481e18195b2d477572fdffa8ed1065f73ef5a19777"
+                    "url": "https://github.com/openssl/openssl/archive/OpenSSL_1_1_1n.tar.gz",
+                    "sha256": "6b2d2440ced8c802aaa61475919f0870ec556694c466ebea460e35ea2b14839e"
                 }
             ],
             "cleanup": [
@@ -97,8 +97,8 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/debauchee/barrier.git",
-                    "tag" : "v2.3.3",
-                    "commit" : "3395cca9673b645ddce3bac9141f148752f9494c"
+                    "tag" : "v2.3.4",
+                    "commit" : "c43597c27a4e57b0b599d41360bc4d29bd7bfe48"
                 },
                 {
                     "type" : "file",


### PR DESCRIPTION
Barrier v2.4.0 fails to build, because this [fix](https://github.com/debauchee/barrier/commit/4b12265ae5d324b942698a3177e1d8b1749414d7) is not included in a v2.4.0 tag
```
-- Generating done
-- Build files have been written to: /run/build/barrier
[18/225] Building CXX object src/lib/base/CMakeFiles/base.dir/EventTypes.cpp.o
FAILED: src/lib/base/CMakeFiles/base.dir/EventTypes.cpp.o 
/usr/bin/c++ -DBARRIER_BUILD_DATE=\"20220407\" -DBARRIER_BUILD_NUMBER=1 -DBARRIER_REVISION=\"3e0d758b\" -DBARRIER_VERSION=\"2.4.0-release\" -DBARRIER_VERSION_MAJOR=2 -DBARRIER_VERSION_MINOR=4 -DBARRIER_VERSION_PATCH=0 -DBARRIER_VERSION_STRING=\"2.4.0-release-release\" -DHAVE_CONFIG_H -DNDEBUG -DSYSAPI_UNIX=1 -DWINAPI_XWINDOWS=1 -I/run/build/barrier/ext/gulrak-filesystem/include -I/run/build/barrier/src/./lib -I/run/build/barrier/src/lib -isystem /app/include/avahi-compat-libdns_sd -O2 -g -pipe -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -fPIC -std=c++14 -MD -MT src/lib/base/CMakeFiles/base.dir/EventTypes.cpp.o -MF src/lib/base/CMakeFiles/base.dir/EventTypes.cpp.o.d -o src/lib/base/CMakeFiles/base.dir/EventTypes.cpp.o -c /run/build/barrier/src/lib/base/EventTypes.cpp
In file included from /run/build/barrier/src/./lib/base/EventTypes.h:20,
                 from /run/build/barrier/src/lib/base/EventTypes.cpp:18:
/run/build/barrier/src/./lib/base/Event.h:63:37: error: ‘NULL’ was not declared in this scope
   63 |     Event(Type type, void* target = NULL, void* data = NULL,
      |                                     ^~~~
/run/build/barrier/src/./lib/base/Event.h:23:1: note: ‘NULL’ is defined in header ‘<cstddef>’; did you forget to ‘#include <cstddef>’?
   22 | #include "common/stdmap.h"
  +++ |+#include <cstddef>
   23 | 
/run/build/barrier/src/./lib/base/Event.h:63:56: error: ‘NULL’ was not declared in this scope
   63 |     Event(Type type, void* target = NULL, void* data = NULL,
      |                                                        ^~~~
/run/build/barrier/src/./lib/base/Event.h:63:56: note: ‘NULL’ is defined in header ‘<cstddef>’; did you forget to ‘#include <cstddef>’?
[20/225] Building CXX object src/lib/base/CMakeFiles/base.dir/Event.cpp.o
FAILED: src/lib/base/CMakeFiles/base.dir/Event.cpp.o 
/usr/bin/c++ -DBARRIER_BUILD_DATE=\"20220407\" -DBARRIER_BUILD_NUMBER=1 -DBARRIER_REVISION=\"3e0d758b\" -DBARRIER_VERSION=\"2.4.0-release\" -DBARRIER_VERSION_MAJOR=2 -DBARRIER_VERSION_MINOR=4 -DBARRIER_VERSION_PATCH=0 -DBARRIER_VERSION_STRING=\"2.4.0-release-release\" -DHAVE_CONFIG_H -DNDEBUG -DSYSAPI_UNIX=1 -DWINAPI_XWINDOWS=1 -I/run/build/barrier/ext/gulrak-filesystem/include -I/run/build/barrier/src/./lib -I/run/build/barrier/src/lib -isystem /app/include/avahi-compat-libdns_sd -O2 -g -pipe -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -fPIC -std=c++14 -MD -MT src/lib/base/CMakeFiles/base.dir/Event.cpp.o -MF src/lib/base/CMakeFiles/base.dir/Event.cpp.o.d -o src/lib/base/CMakeFiles/base.dir/Event.cpp.o -c /run/build/barrier/src/lib/base/Event.cpp
In file included from /run/build/barrier/src/lib/base/Event.cpp:19:
/run/build/barrier/src/./lib/base/Event.h:63:37: error: ‘NULL’ was not declared in this scope
   63 |     Event(Type type, void* target = NULL, void* data = NULL,
      |                                     ^~~~
/run/build/barrier/src/./lib/base/Event.h:23:1: note: ‘NULL’ is defined in header ‘<cstddef>’; did you forget to ‘#include <cstddef>’?
   22 | #include "common/stdmap.h"
  +++ |+#include <cstddef>
   23 | 
/run/build/barrier/src/./lib/base/Event.h:63:56: error: ‘NULL’ was not declared in this scope
   63 |     Event(Type type, void* target = NULL, void* data = NULL,
      |                                                        ^~~~
/run/build/barrier/src/./lib/base/Event.h:63:56: note: ‘NULL’ is defined in header ‘<cstddef>’; did you forget to ‘#include <cstddef>’?
[25/225] Building CXX object src/CMakeFi...test.dir/__/ext/gtest/src/gtest-all.cc.o
ninja: build stopped: subcommand failed.
Error: module barrier: Child process exited with code 1
```