### PR TITLE
[Update] barrier bump to v2.4.0, KDE runtime to 5.15-22.08

### DIFF
--- a/barrier_git_v2.4.0.patch
+++ b/barrier_git_v2.4.0.patch
@@ -1,0 +1,13 @@
+diff --git a/src/lib/base/Event.h b/src/lib/base/Event.h
+index 38a2cf11..cb00dccb 100644
+--- a/src/lib/base/Event.h
++++ b/src/lib/base/Event.h
+@@ -21,6 +21,8 @@
+ #include "common/basic_types.h"
+ #include "common/stdmap.h"
+
++#include <cstddef>
++
+ class EventData {
+ public:
+     EventData() { }

--- a/com.github.debauchee.barrier.appdata.xml
+++ b/com.github.debauchee.barrier.appdata.xml
@@ -24,6 +24,7 @@
   <launchable type="desktop-id">com.github.debauchee.barrier.desktop</launchable>
 
   <releases>
+    <release date="2022-11-08" version="2.4.0" urgency="medium" />
     <release date="2022-03-07" version="2.3.4" urgency="medium" />
     <release date="2020-07-14" version="2.3.3" urgency="medium" />
     <release date="2019-09-03" version="2.3.2" urgency="medium" />
@@ -55,7 +56,7 @@
     </screenshot>
   </screenshots>
 
-  <update_contact>barrier+flatpak@shymega.org.uk</update_contact>
+  <update_contact>miotk.mikolaj+flatpak-barrier@gmail.com</update_contact>
 
   <content_rating type="oars-1.1" />
 </component>

--- a/com.github.debauchee.barrier.json
+++ b/com.github.debauchee.barrier.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.github.debauchee.barrier",
     "runtime" : "org.kde.Platform",
-    "runtime-version" : "5.15-21.08",
+    "runtime-version" : "5.15-22.08",
     "sdk" : "org.kde.Sdk",
     "command" : "barrier",
     "rename-icon" : "barrier",
@@ -36,8 +36,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/openssl/openssl/archive/OpenSSL_1_1_1n.tar.gz",
-                    "sha256": "6b2d2440ced8c802aaa61475919f0870ec556694c466ebea460e35ea2b14839e"
+                    "url": "https://github.com/openssl/openssl/archive/OpenSSL_1_1_1s.tar.gz",
+                    "sha256": "0dc03a5842801884e25211d81f9fa8d2fce5aad6a9e996eac0deb68994a80243"
                 }
             ],
             "cleanup": [
@@ -97,8 +97,12 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/debauchee/barrier.git",
-                    "tag" : "v2.3.4",
-                    "commit" : "c43597c27a4e57b0b599d41360bc4d29bd7bfe48"
+                    "tag" : "v2.4.0",
+                    "commit" : "3e0d758b59e44e6bb8b5e13cf96c824be44207ac"
+                },
+                {
+                    "type" : "patch",
+                    "path" : "barrier_git_v2.4.0.patch"
                 },
                 {
                     "type" : "file",

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,18 @@
+# com.github.debauchee.barrier
+
+## How to build
+
+1. Install flatpak-builder, i.e: `dnf install flatpak-builder`
+2. Install corresponding runtime and SDK, i.e.: `flatpak install org.kde.Sdk/x86_64/5.15-21.08` `flatpak install org.kde.Platform/x86_64/5.15-21.08`
+3. Build by executing: `flatpak-builder build com.github.debauchee.barrier.json --force-clean`
+
+   - if you encounter an issue `fatal: transport 'file' not allowed` during build execute `git config --global --add protocol.file.allow always` to fix it:
+
+     ```bash
+     Cloning into '/home/user/com.github.debauchee.barrier/.flatpak-builder/build/barrier-10/ext/gtest'...
+     fatal: transport 'file' not allowed
+     fatal: clone of 'file:///home/user/com.github.debauchee.barrier/.flatpak-builder/git/https_github.com_google_googletest.git' into submodule path '/home/user/com.github.debauchee.barrier/.flatpak-builder/build/barrier-10/ext/gtest' failed
+     ```
+
+4. Install a build: `flatpak-builder --user --install --force-clean build com.github.debauchee.barrier.json`
+5. Test the build: `flatpak run com.github.debauchee.barrier`


### PR DESCRIPTION
Hi all,

As mentioned in my previous PR https://github.com/flathub/com.github.debauchee.barrier/pull/27, I needed to add a git patch to work around a missing `<cstddef>` library header and to fix a failing build.