### PR TITLE
Drop org.kde.* own-name

### DIFF
--- a/com.github.debauchee.barrier.json
+++ b/com.github.debauchee.barrier.json
@@ -10,7 +10,6 @@
         "--share=ipc",
         "--socket=x11",
         "--share=network",
-        "--own-name=org.kde.*",
         "--talk-name=org.a11y.*",
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--system-talk-name=org.freedesktop.Avahi",


### PR DESCRIPTION
This is no longer required with any supported runtimes, the issue was fixed in Qt

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement

https://github.com/flathub/flatpak-builder-lint/issues/ 66#issuecomment-1386033025