### PR TITLE
Update kde runtime version to 5.15-23.08 and bump the version of OpenSSL

### DIFF
--- a/barrier_git_v2.4.0_kde23.08.patch
+++ b/barrier_git_v2.4.0_kde23.08.patch
@@ -1,0 +1,36 @@
+diff --git a/src/lib/base/String.h b/src/lib/base/String.h
+index 9c5a53ba..2ff2e349 100644
+--- a/src/lib/base/String.h
++++ b/src/lib/base/String.h
+@@ -21,6 +21,7 @@
+ #include "common/common.h"
+ #include "common/stdstring.h"
+ 
++#include <cstdint>
+ #include <stdarg.h>
+ #include <vector>
+ 
+diff --git a/src/lib/base/XBase.h b/src/lib/base/XBase.h
+index 0b467502..f6250de8 100644
+--- a/src/lib/base/XBase.h
++++ b/src/lib/base/XBase.h
+@@ -18,6 +18,7 @@
+ 
+ #pragma once
+ 
++#include <cstdint>
+ #include <stdexcept>
+ #include <string>
+ 
+diff --git a/src/lib/net/FingerprintData.h b/src/lib/net/FingerprintData.h
+index 938a6953..522a4813 100644
+--- a/src/lib/net/FingerprintData.h
++++ b/src/lib/net/FingerprintData.h
+@@ -18,6 +18,7 @@
+ #ifndef BARRIER_LIB_NET_FINGERPRINT_DATA_H
+ #define BARRIER_LIB_NET_FINGERPRINT_DATA_H
+ 
++#include <cstdint>
+ #include <string>
+ #include <vector>
+ 

--- a/com.github.debauchee.barrier.appdata.xml
+++ b/com.github.debauchee.barrier.appdata.xml
@@ -24,6 +24,7 @@
   <launchable type="desktop-id">com.github.debauchee.barrier.desktop</launchable>
 
   <releases>
+    <release date="2024-10-23" version="2.4.0-5.15-23.08" urgency="medium" />
     <release date="2022-11-08" version="2.4.0" urgency="medium" />
     <release date="2022-03-07" version="2.3.4" urgency="medium" />
     <release date="2020-07-14" version="2.3.3" urgency="medium" />

--- a/com.github.debauchee.barrier.appdata.xml
+++ b/com.github.debauchee.barrier.appdata.xml
@@ -40,7 +40,6 @@
   <developer_name>Siix</developer_name>
 
   <translation type="gettext">avahi</translation>
-  <launchable type="desktop-id">barrier.desktop</launchable>
 
   <screenshots>
     <screenshot type="default">

--- a/com.github.debauchee.barrier.json
+++ b/com.github.debauchee.barrier.json
@@ -104,6 +104,10 @@
                     "path" : "barrier_git_v2.4.0.patch"
                 },
                 {
+                    "type" : "patch",
+                    "path" : "barrier_git_v2.4.0_kde23.08.patch"
+                },
+                {
                     "type" : "file",
                     "path" : "com.github.debauchee.barrier.appdata.xml"
                 }

--- a/com.github.debauchee.barrier.json
+++ b/com.github.debauchee.barrier.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.github.debauchee.barrier",
     "runtime" : "org.kde.Platform",
-    "runtime-version" : "5.15-22.08",
+    "runtime-version" : "5.15-23.08",
     "sdk" : "org.kde.Sdk",
     "command" : "barrier",
     "rename-icon" : "barrier",
@@ -35,8 +35,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/openssl/openssl/archive/OpenSSL_1_1_1s.tar.gz",
-                    "sha256": "0dc03a5842801884e25211d81f9fa8d2fce5aad6a9e996eac0deb68994a80243"
+                    "url": "https://github.com/openssl/openssl/archive/OpenSSL_1_1_1w.tar.gz",
+                    "sha256": "2130e8c2fb3b79d1086186f78e59e8bc8d1a6aedf17ab3907f4cb9ae20918c41"
                 }
             ],
             "cleanup": [

--- a/readme.md
+++ b/readme.md
@@ -2,9 +2,10 @@
 
 ## How to build
 
-1. Install flatpak-builder, i.e: `dnf install flatpak-builder`
-2. Install corresponding runtime and SDK, i.e.: `flatpak install org.kde.Sdk/x86_64/5.15-21.08` `flatpak install org.kde.Platform/x86_64/5.15-21.08`
-3. Build by executing: `flatpak-builder build com.github.debauchee.barrier.json --force-clean`
+1. Clone repo with submodules: `git clone --recursive git@github.com:flathub/com.github.debauchee.barrier.git`
+2. Install flatpak-builder, i.e: `dnf install flatpak-builder`
+3. Install corresponding runtime and SDK, i.e.: `flatpak install org.kde.Sdk/x86_64/5.15-23.08` `flatpak install org.kde.Platform/x86_64/5.15-23.08`
+4. Build by executing: `flatpak-builder build com.github.debauchee.barrier.json --force-clean`
 
    - if you encounter an issue `fatal: transport 'file' not allowed` during build execute `git config --global --add protocol.file.allow always` to fix it:
 
@@ -14,5 +15,5 @@
      fatal: clone of 'file:///home/user/com.github.debauchee.barrier/.flatpak-builder/git/https_github.com_google_googletest.git' into submodule path '/home/user/com.github.debauchee.barrier/.flatpak-builder/build/barrier-10/ext/gtest' failed
      ```
 
-4. Install a build: `flatpak-builder --user --install --force-clean build com.github.debauchee.barrier.json`
-5. Test the build: `flatpak run com.github.debauchee.barrier`
+5. Install a build: `flatpak-builder --user --install --force-clean build com.github.debauchee.barrier.json`
+6. Test the build: `flatpak run com.github.debauchee.barrier`


### PR DESCRIPTION
Simple bump of the runtime version is not a solution, needed to add one more patch to solve the application code compile issue:

```
[15/225] Building CXX object src/lib/base/CMakeFiles/base.dir/XBase.cpp.o
FAILED: src/lib/base/CMakeFiles/base.dir/XBase.cpp.o 
/usr/bin/c++ -DBARRIER_BUILD_DATE=\"20241023\" -DBARRIER_BUILD_NUMBER=1 -DBARRIER_REVISION=\"3e0d758b\" -DBARRIER_VERSION=\"2.4.0-release\" -DBARRIER_VERSION_MAJOR=2 -DBARRIER_VERSION_MINOR=4 -DBARRIER_VERSION_PATCH=0 -DBARRIER_VERSION_STRING=\"2.4.0-release-release\" -DHAVE_CONFIG_H -DNDEBUG -DSYSAPI_UNIX=1 -DWINAPI_XWINDOWS=1 -I/run/build/barrier/ext/gulrak-filesystem/include -I/run/build/barrier/src/./lib -I/run/build/barrier/src/lib -isystem /app/include/avahi-compat-libdns_sd -O2 -pipe -g -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -std=c++14 -fPIC -MD -MT src/lib/base/CMakeFiles/base.dir/XBase.cpp.o -MF src/lib/base/CMakeFiles/base.dir/XBase.cpp.o.d -o src/lib/base/CMakeFiles/base.dir/XBase.cpp.o -c /run/build/barrier/src/lib/base/XBase.cpp
In file included from /run/build/barrier/src/lib/base/XBase.cpp:20:
/run/build/barrier/src/./lib/base/String.h:78:43: error: ‘uint8_t’ is not a member of ‘std’; did you mean ‘wint_t’?
   78 | std::string to_hex(const std::vector<std::uint8_t>& subject, int width, const char fill = '0');
      |                                           ^~~~~~~
      |                                           wint_t
/run/build/barrier/src/./lib/base/String.h:78:43: error: ‘uint8_t’ is not a member of ‘std’; did you mean ‘wint_t’?
   78 | std::string to_hex(const std::vector<std::uint8_t>& subject, int width, const char fill = '0');
      |                                           ^~~~~~~
      |                                           wint_t
/run/build/barrier/src/./lib/base/String.h:78:50: error: template argument 1 is invalid
   78 | std::string to_hex(const std::vector<std::uint8_t>& subject, int width, const char fill = '0');
      |                                                  ^
/run/build/barrier/src/./lib/base/String.h:78:50: error: template argument 2 is invalid
/run/build/barrier/src/./lib/base/String.h:81:18: error: ‘uint8_t’ is not a member of ‘std’; did you mean ‘wint_t’?
   81 | std::vector<std::uint8_t> from_hex(const std::string& data);
      |                  ^~~~~~~
      |                  wint_t
/run/build/barrier/src/./lib/base/String.h:81:18: error: ‘uint8_t’ is not a member of ‘std’; did you mean ‘wint_t’?
   81 | std::vector<std::uint8_t> from_hex(const std::string& data);
      |                  ^~~~~~~
      |                  wint_t
/run/build/barrier/src/./lib/base/String.h:81:25: error: template argument 1 is invalid
   81 | std::vector<std::uint8_t> from_hex(const std::string& data);
      |                         ^
```

Solves: 
- #34 
- #33 